### PR TITLE
Use module name 'CZLib' so there is no conflict with system-provided zlib

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,5 +3,5 @@
 import PackageDescription
 
 let package = Package(
-    name: "zlib"
+    name: "CZLib"
 )

--- a/module.modulemap
+++ b/module.modulemap
@@ -1,4 +1,4 @@
-module zlib [system] {
+module CZLib [system] {
     header "zconf.h"
     header "zlib.h"
     link "z"


### PR DESCRIPTION
Module 'zlib' is present with XCode 9 or higher, which leads to 'module redefinition error' when importing this module. Changing the name to 'CZLib' fixes the issue.