### PR TITLE
Add Package.swift for SwiftPM ver.4

### DIFF
--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -1,0 +1,16 @@
+// swift-tools-version:4.0
+
+import PackageDescription
+
+let package = Package(
+    name: "SSCZLib",
+    products: [
+        .library(name: "SSCZLib", targets: ["SSCZLib"])
+    ],
+    targets: [
+        .target(
+             name: "SSCZLib",
+             dependencies: []
+        ),
+    ]
+)


### PR DESCRIPTION
Hi @daltoniam.
I added Package@swift-4.swift for that Starscream supports Swift Package Manager v4.